### PR TITLE
permit pathnames, e.g. "/Volumes/Bubba Two/rarch", with embedded spaces

### DIFF
--- a/bin/reader_archive
+++ b/bin/reader_archive
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ROOT_DIR=$(dirname $0)/..
-PYTHONPATH=$ROOT_DIR /usr/bin/env python2.7 $ROOT_DIR/reader_archive/reader_archive.py $*
+PYTHONPATH=$ROOT_DIR /usr/bin/env python2.7 $ROOT_DIR/reader_archive/reader_archive.py "$@"


### PR DESCRIPTION
Per http://stackoverflow.com/questions/7535677/bash-passing-paths-with-spaces-as-parameters, allowed me to back up to another Volume that was named with an embedded space.
